### PR TITLE
Support opening files using Path objects.

### DIFF
--- a/h5pickle/__init__.py
+++ b/h5pickle/__init__.py
@@ -23,7 +23,6 @@ h5py
 cachetools
 """
 
-import json
 import h5py
 from cachetools import LRUCache
 
@@ -90,7 +89,7 @@ class Group(PickleAbleH5PyObject, h5py.Group):
 
 
 def arghash(*args, **kwargs):
-    return hash(json.dumps(args) + json.dumps(kwargs, sort_keys=True))
+    return hash((args, tuple(sorted(kwargs.items()))))
 
 
 class File(h5py.File):


### PR DESCRIPTION
Currently `h5pickle.File(pathlib.Path("foo.h5"))` fails with
"TypeError: Object of type PosixPath is not JSON serializable"
but json-serialization isn't really needed; one can just hash all
arguments and call it a day.